### PR TITLE
Add setting focus on page load to pages with search box

### DIFF
--- a/src/UWPResourcesGallery/DebugPackage.appxmanifest
+++ b/src/UWPResourcesGallery/DebugPackage.appxmanifest
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 
 <Package
   xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
@@ -9,7 +9,7 @@
   <Identity
     Name="UWP-Resourcess-Gallery-Debug"
     Publisher="CN=Marcel Wagner"
-    Version="1.2.2.0" />
+    Version="1.2.3.0" />
 
   <mp:PhoneIdentity PhoneProductId="6245fa1a-e391-413d-9b02-a4ae1f060713" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
 

--- a/src/UWPResourcesGallery/Package.appxmanifest
+++ b/src/UWPResourcesGallery/Package.appxmanifest
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 
 <Package
   xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
@@ -9,7 +9,7 @@
   <Identity
     Name="UWP-Resourcess-Gallery"
     Publisher="CN=Marcel Wagner"
-    Version="1.2.2.0" />
+    Version="1.2.3.0" />
 
   <mp:PhoneIdentity PhoneProductId="6245fa1a-e391-413d-9b02-a4ae1f060713" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
 

--- a/src/UWPResourcesGallery/Pages/IconsListPage.xaml.cs
+++ b/src/UWPResourcesGallery/Pages/IconsListPage.xaml.cs
@@ -25,6 +25,8 @@ namespace UWPResourcesGallery.Pages
 
         private void LoadIcons(object sender, Windows.UI.Xaml.RoutedEventArgs e)
         {
+            Focus(Windows.UI.Xaml.FocusState.Programmatic);
+            
             // Delegate loading of icons, so we have smooth navigating to this page
             // and not unecessarly block UI Thread
             Task.Run(delegate ()

--- a/src/UWPResourcesGallery/Pages/SystemBrushesPage.xaml.cs
+++ b/src/UWPResourcesGallery/Pages/SystemBrushesPage.xaml.cs
@@ -24,6 +24,7 @@ namespace UWPResourcesGallery.Pages
 
         private void LoadSystemColors(object sender, Windows.UI.Xaml.RoutedEventArgs e)
         {
+            Focus(Windows.UI.Xaml.FocusState.Programmatic);
             // Delegate loading of system colors, so we have smooth navigating to this page 
             // and not unecessarly block UI Thread
             Task.Run(delegate ()

--- a/src/UWPResourcesGallery/Pages/SystemColorsPage.xaml.cs
+++ b/src/UWPResourcesGallery/Pages/SystemColorsPage.xaml.cs
@@ -24,6 +24,7 @@ namespace UWPResourcesGallery.Pages
 
         private void LoadSystemColors(object sender, Windows.UI.Xaml.RoutedEventArgs e)
         {
+            Focus(Windows.UI.Xaml.FocusState.Programmatic);
             // Delegate loading of system colors, so we have smooth navigating to this page 
             // and not unecessarly block UI Thread
             Task.Run(delegate ()

--- a/src/UWPResourcesGallery/Pages/UniversalContractsPage.xaml.cs
+++ b/src/UWPResourcesGallery/Pages/UniversalContractsPage.xaml.cs
@@ -47,6 +47,12 @@ namespace UWPResourcesGallery.Pages
             UniversalVersionsPresenterContainer.ItemsSource = source.FilteredItems;
             SelectedItem = source.FilteredItems[0];
             Analytics.TrackEvent("Visited: UniversalContractsPage");
+            Loaded += UniversalContractsPage_Loaded;
+        }
+
+        private void UniversalContractsPage_Loaded(object sender, RoutedEventArgs e)
+        {
+            Focus(Windows.UI.Xaml.FocusState.Programmatic);
         }
 
         private void SearchTextBox_TextChanged(object sender, TextChangedEventArgs args)


### PR DESCRIPTION
Sets focus on page loaded event to the page, resulting in the search box being focused. Fixes #28 