### PR TITLE
Update CI to pass again

### DIFF
--- a/build/pipeline/azure-pipelines.ci.yml
+++ b/build/pipeline/azure-pipelines.ci.yml
@@ -7,7 +7,7 @@ trigger:
 - master
 
 pool:
-  vmImage: 'windows-2016'
+  vmImage: 'windows-2019'
 
 stages:
   - stage: Build

--- a/build/pipeline/azure-pipelines.main.yml
+++ b/build/pipeline/azure-pipelines.main.yml
@@ -7,7 +7,7 @@ trigger:
 - master
 
 pool:
-  vmImage: 'windows-2016'
+  vmImage: 'windows-2019'
 
 variables:
   solution: '**/*.sln'

--- a/build/pipeline/templates/build-all.yml
+++ b/build/pipeline/templates/build-all.yml
@@ -9,9 +9,9 @@ jobs:
     displayName: Build ${{parameters.buildConfiguration}} ${{parameters.buildPlatform}}
     steps:
     - task: NuGetToolInstaller@1
-      displayName: Install NuGet 5.2.0
+      displayName: Install NuGet 5.8.0
       inputs:
-        versionSpec: 5.2.0
+        versionSpec: 5.8.0
 
     - task: NuGetCommand@2
       displayName: Restore packages

--- a/build/pipeline/templates/test-interaction-tests.yml
+++ b/build/pipeline/templates/test-interaction-tests.yml
@@ -9,12 +9,21 @@ jobs:
   - job: 
     displayName: Interaction tests ${{parameters.buildConfiguration}} ${{parameters.buildPlatform}}
     steps:
-      - checkout: none
-      - task: DownloadPipelineArtifact@2
+      - task: NuGetToolInstaller@1
+        displayName: Install NuGet 5.8.0
         inputs:
-          buildType: 'current'
-          artifactName: 'artifacts_${{parameters.buildConfiguration}}_${{parameters.buildPlatform}}'
-          targetPath: '$(System.DefaultWorkingDirectory)\artifacts\${{parameters.buildConfiguration}}'
+          versionSpec: 5.8.0
+
+      - task: NuGetCommand@2
+        displayName: Restore packages
+        inputs:
+          restoreSolution: '${{parameters.solution}}'
+
+      - task: DownloadPipelineArtifact@2
+          inputs:
+            buildType: 'current'
+            artifactName: 'artifacts_${{parameters.buildConfiguration}}_${{parameters.buildPlatform}}'
+            targetPath: '$(System.DefaultWorkingDirectory)\artifacts\${{parameters.buildConfiguration}}'
       
       - task: DownloadPipelineArtifact@2
         inputs:

--- a/build/pipeline/templates/test-interaction-tests.yml
+++ b/build/pipeline/templates/test-interaction-tests.yml
@@ -62,7 +62,7 @@ jobs:
         inputs:
           testSelector: 'testAssemblies'
           testAssemblyVer2: |
-            **UWPResourcesGallery.AppInteractionTests.dll
+            **\UWPResourcesGallery.AppInteractionTests.dll
             !**\*TestAdapter.dll
             !**\obj\**
           searchFolder: '$(System.DefaultWorkingDirectory)'

--- a/build/pipeline/templates/test-interaction-tests.yml
+++ b/build/pipeline/templates/test-interaction-tests.yml
@@ -62,7 +62,7 @@ jobs:
         inputs:
           testSelector: 'testAssemblies'
           testAssemblyVer2: |
-            **\UWPResourcesGallery.AppInteractionTests.dll
+            **\AnyCPU\UWPResourcesGallery.AppInteractionTests\net5.0\UWPResourcesGallery.AppInteractionTests.dll
             !**\*TestAdapter.dll
             !**\obj\**
           searchFolder: '$(System.DefaultWorkingDirectory)'

--- a/build/pipeline/templates/test-interaction-tests.yml
+++ b/build/pipeline/templates/test-interaction-tests.yml
@@ -62,7 +62,7 @@ jobs:
         inputs:
           testSelector: 'testAssemblies'
           testAssemblyVer2: |
-            **AnyCPU\UWPResourcesGallery.AppInteractionTests\net5.0\UWPResourcesGallery.AppInteractionTests.dll
+            **UWPResourcesGallery.AppInteractionTests.dll
             !**\*TestAdapter.dll
             !**\obj\**
           searchFolder: '$(System.DefaultWorkingDirectory)'

--- a/build/pipeline/templates/test-interaction-tests.yml
+++ b/build/pipeline/templates/test-interaction-tests.yml
@@ -62,7 +62,7 @@ jobs:
         inputs:
           testSelector: 'testAssemblies'
           testAssemblyVer2: |
-            **\*AppInteractionTests**.dll
+            **AnyCPU\UWPResourcesGallery.AppInteractionTests\net5.0\UWPResourcesGallery.AppInteractionTests.dll
             !**\*TestAdapter.dll
             !**\obj\**
           searchFolder: '$(System.DefaultWorkingDirectory)'

--- a/build/pipeline/templates/test-interaction-tests.yml
+++ b/build/pipeline/templates/test-interaction-tests.yml
@@ -20,10 +20,10 @@ jobs:
           restoreSolution: '${{parameters.solution}}'
 
       - task: DownloadPipelineArtifact@2
-          inputs:
-            buildType: 'current'
-            artifactName: 'artifacts_${{parameters.buildConfiguration}}_${{parameters.buildPlatform}}'
-            targetPath: '$(System.DefaultWorkingDirectory)\artifacts\${{parameters.buildConfiguration}}'
+        inputs:
+          buildType: 'current'
+          artifactName: 'artifacts_${{parameters.buildConfiguration}}_${{parameters.buildPlatform}}'
+          targetPath: '$(System.DefaultWorkingDirectory)\artifacts\${{parameters.buildConfiguration}}'
       
       - task: DownloadPipelineArtifact@2
         inputs:

--- a/build/pipeline/templates/test-unit-tests.yml
+++ b/build/pipeline/templates/test-unit-tests.yml
@@ -11,9 +11,9 @@ jobs:
     steps:
 
       - task: NuGetToolInstaller@1
-        displayName: Install NuGet 5.2.0
+        displayName: Install NuGet 5.8.0
         inputs:
-          versionSpec: 5.2.0
+          versionSpec: 5.8.0
 
       - task: NuGetCommand@2
         displayName: Restore packages

--- a/tests/UWPResourcesGallery.AppInteractionTests/UWPResourcesGallery.AppInteractionTests.csproj
+++ b/tests/UWPResourcesGallery.AppInteractionTests/UWPResourcesGallery.AppInteractionTests.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Appium.WebDriver" Version="4.2.1" />
     <PackageReference Include="Axe.Windows" Version="1.0.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.0-preview-20201020-06" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
   </ItemGroup>

--- a/tests/UWPResourcesGallery.AppInteractionTests/UWPResourcesGallery.AppInteractionTests.csproj
+++ b/tests/UWPResourcesGallery.AppInteractionTests/UWPResourcesGallery.AppInteractionTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>UWPResourcesGallery.AppInteractionTests</RootNamespace>
 
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
Issue was that the new images use .Net 5, compiling a .Net Core 3.0 project doesn't work anymore.