### PR TITLE
Update analyzer references

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
   <!-- Packages needed in every project -->
   <ItemGroup>
     <!-- Code analyzer -->
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.2">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.1">
     </PackageReference>
   </ItemGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,12 +8,16 @@
 
     <IntermediateOutputPath>..\..\artifacts\intermediates\$(Platform)\$(MSBuildProjectName)\</IntermediateOutputPath>
     <GeneratedFilesDir>..\..\artifacts\intermediates\$(Platform)\$(MSBuildProjectName)\Generated Files\</GeneratedFilesDir>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
   </PropertyGroup>
-  
+
   <!-- Packages needed in every project -->
   <ItemGroup>
     <!-- Code analyzer -->
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.1">
-    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.1"/>
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.2"/>
+    <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="3.3.2"/>
   </ItemGroup>
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -6,14 +6,17 @@
 
       CA1305: Specify IFormatProvider
       Ignore reason: All strings are english
-      
+
       WMC1501: Property is for evaluation purposes
       Ignore reason: We are fine with that here
-      
+
       CS8305: Property is for evaluation purposes
       Ignore reason: We are fine with that here
+
+      CA9998: FxCopAnalyzers package has been deprecated in favor of 'Microsoft.CodeAnalysis.NetAnalyzers'
+      Ignore reason: They don't seem to work well with UWP.
       -->
 
-    <NoWarn>;$(NoWarn);CA1303;CA1305;WMC1501;CS8305;</NoWarn>
+    <NoWarn>;$(NoWarn);CA1303;CA1305;WMC1501;CS8305;CA9998</NoWarn>
   </PropertyGroup>
 </Project>

--- a/src/UWPResourcesGallery/Controls/Templates/IconItemControl.xaml.cs
+++ b/src/UWPResourcesGallery/Controls/Templates/IconItemControl.xaml.cs
@@ -5,7 +5,7 @@ using Windows.UI.Xaml.Controls;
 
 namespace UWPResourcesGallery.Controls.Templates
 {
-    public partial class IconItemControl : UserControl
+    public sealed partial class IconItemControl : UserControl
     {
 
         public UIElement IconViewPresenter => IconView;

--- a/tests/UWPResourcesGallery.AppInteractionTests/TestHelper.cs
+++ b/tests/UWPResourcesGallery.AppInteractionTests/TestHelper.cs
@@ -2,6 +2,8 @@
 using System;
 using System.Collections.Generic;
 
+[assembly: CLSCompliant(false)]
+
 namespace UWPResourcesGallery.AppInteractionTests
 {
     internal class TestHelper


### PR DESCRIPTION
This PR updates the analyzer references to also include the new .NET 5.0 analyzers so they run once they work with UWP or we switch to .NET 5.0